### PR TITLE
日記入力画面のデザインを実装する

### DIFF
--- a/apps/native/app.config.ts
+++ b/apps/native/app.config.ts
@@ -23,6 +23,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     bundleIdentifier: "net.uiro.noval-ios",
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
+      NSPhotoLibraryUsageDescription:
+        "日記に写真を添付するためにフォトライブラリへのアクセスが必要です。",
     },
   },
   android: {
@@ -35,7 +37,17 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   web: {
     favicon: "./assets/favicon.png",
   },
-  plugins: ["expo-router", "expo-font"],
+  plugins: [
+    "expo-router",
+    "expo-font",
+    [
+      "expo-image-picker",
+      {
+        photosPermission:
+          "日記に写真を添付するためにフォトライブラリへのアクセスが必要です。",
+      },
+    ],
+  ],
   extra: {
     eas: {
       projectId: "094a0763-1c2d-4e08-a364-665289a4f7ef",

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -30,6 +30,7 @@
     "expo-constants": "^18.0.12",
     "expo-device": "^8.0.10",
     "expo-font": "~14.0.10",
+    "expo-image-picker": "~17.0.10",
     "expo-linking": "^8.0.10",
     "expo-router": "~6.0.19",
     "expo-secure-store": "^15.0.8",

--- a/apps/native/src/screens/diary/diary-input-screen.tsx
+++ b/apps/native/src/screens/diary/diary-input-screen.tsx
@@ -1,28 +1,154 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
 import { Button } from "heroui-native";
-import { Text, View } from "react-native";
+import { useState } from "react";
+import {
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  TextInput,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { withUniwind } from "uniwind";
 
 const StyledView = withUniwind(View);
-const StyledText = withUniwind(Text);
+const StyledTextInput = withUniwind(TextInput);
+const StyledImage = withUniwind(Image);
+const StyledPressable = withUniwind(Pressable);
+const StyledKeyboardAvoidingView = withUniwind(KeyboardAvoidingView);
+const StyledIonicons = withUniwind(Ionicons);
+
+interface SelectedImage {
+  uri: string;
+  width: number;
+  height: number;
+}
 
 export const DiaryInputScreen = () => {
   const router = useRouter();
   const insets = useSafeAreaInsets();
 
-  return (
-    <StyledView
-      className="flex-1 items-center justify-center bg-background px-4"
-      style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
-    >
-      <StyledText className="mb-8 font-bold text-2xl text-foreground">
-        日記入力画面
-      </StyledText>
+  const [content, setContent] = useState("");
+  const [selectedImage, setSelectedImage] = useState<SelectedImage | null>(
+    null,
+  );
 
-      <Button variant="secondary" onPress={() => router.back()}>
-        <Button.Label>閉じる</Button.Label>
-      </Button>
-    </StyledView>
+  const handleClose = () => {
+    router.back();
+  };
+
+  const handlePost = () => {
+    console.log("投稿内容:", {
+      content,
+      image: selectedImage,
+    });
+    router.back();
+  };
+
+  const handlePickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ["images"],
+      allowsEditing: false,
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets[0]) {
+      const asset = result.assets[0];
+      setSelectedImage({
+        uri: asset.uri,
+        width: asset.width,
+        height: asset.height,
+      });
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setSelectedImage(null);
+  };
+
+  const canPost = content.trim().length > 0;
+
+  return (
+    <StyledKeyboardAvoidingView
+      className="flex-1 bg-background"
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      keyboardVerticalOffset={24}
+    >
+      <StyledView
+        className="flex-1"
+        style={{ paddingTop: 5, paddingBottom: insets.bottom }}
+      >
+        {/* ヘッダー */}
+        <StyledView className="flex-row items-center justify-between border-divider/50 border-b px-4 py-3">
+          <Pressable onPress={handleClose}>
+            <StyledIonicons
+              name="close"
+              size={28}
+              className="text-foreground"
+            />
+          </Pressable>
+
+          <Button
+            size="sm"
+            variant="primary"
+            isDisabled={!canPost}
+            onPress={handlePost}
+          >
+            <Button.Label>投稿</Button.Label>
+          </Button>
+        </StyledView>
+
+        {/* テキスト入力エリア */}
+        <StyledView className="flex-1 px-4 pt-4">
+          <StyledTextInput
+            className="flex-1 text-foreground text-lg"
+            placeholder="今日は何を食べましたか？"
+            placeholderTextColor="#9ca3af"
+            multiline
+            textAlignVertical="top"
+            value={content}
+            onChangeText={setContent}
+            autoFocus
+          />
+        </StyledView>
+
+        {/* 画像プレビュー */}
+        {selectedImage && (
+          <StyledView className="px-4 pb-4">
+            <StyledView className="relative overflow-hidden rounded-xl">
+              <StyledImage
+                source={{ uri: selectedImage.uri }}
+                className="h-48 w-full"
+                resizeMode="cover"
+              />
+              <StyledPressable
+                className="absolute top-2 right-2 items-center justify-center rounded-full bg-black/60 p-1.5"
+                onPress={handleRemoveImage}
+              >
+                <StyledIonicons name="close" size={18} className="text-white" />
+              </StyledPressable>
+            </StyledView>
+          </StyledView>
+        )}
+
+        {/* ツールバー */}
+        <StyledView className="flex-row items-center border-divider/50 border-t px-4 py-3">
+          <StyledPressable
+            className="items-center justify-center rounded-full p-2 active:bg-accent/10"
+            onPress={handlePickImage}
+            disabled={selectedImage !== null}
+          >
+            <StyledIonicons
+              name="image-outline"
+              size={24}
+              className={selectedImage ? "text-muted" : "text-accent"}
+            />
+          </StyledPressable>
+        </StyledView>
+      </StyledView>
+    </StyledKeyboardAvoidingView>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       expo-font:
         specifier: ~14.0.10
         version: 14.0.10(expo@54.0.29)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-image-picker:
+        specifier: ~17.0.10
+        version: 17.0.10(expo@54.0.29)
       expo-linking:
         specifier: ^8.0.10
         version: 8.0.10(expo@54.0.29)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -4735,6 +4738,16 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-image-loader@6.0.0:
+    resolution: {integrity: sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-picker@17.0.10:
+    resolution: {integrity: sha512-a2xrowp2trmvXyUWgX3O6Q2rZaa2C59AqivKI7+bm+wLvMfTEbZgldLX4rEJJhM8xtmEDTNU+lzjtObwzBRGaw==}
+    peerDependencies:
+      expo: '*'
 
   expo-keep-awake@15.0.8:
     resolution: {integrity: sha512-YK9M1VrnoH1vLJiQzChZgzDvVimVoriibiDIFLbQMpjYBnvyfUeHJcin/Gx1a+XgupNXy92EQJLgI/9ZuXajYQ==}
@@ -12488,6 +12501,15 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
+
+  expo-image-loader@6.0.0(expo@54.0.29):
+    dependencies:
+      expo: 54.0.29(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.19)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
+  expo-image-picker@17.0.10(expo@54.0.29):
+    dependencies:
+      expo: 54.0.29(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.19)(graphql@16.12.0)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-image-loader: 6.0.0(expo@54.0.29)
 
   expo-keep-awake@15.0.8(expo@54.0.29)(react@19.1.0):
     dependencies:


### PR DESCRIPTION
<!-- issue は draft として作成し、レビューを依頼するときに ready for review として設定してください -->

## 関連 issue

resolve #15

## やったこと

<!-- 概要をPRのタイトルに記載する -->

- KeyboardAvoidingViewでキーボード表示時のレイアウト調整を追加
- 画像プレビューと削除機能を追加

### 追加した依存関係

| パッケージ | バージョン | 用途 |
|-----------|-----------|------|
| `expo-image-picker` | ~17.0.10 | 写真ライブラリからの画像選択 |

### 権限設定（app.config.ts）

- **iOS**: `NSPhotoLibraryUsageDescription` を追加
- **Android**: `expo-image-picker` プラグインで `photosPermission` を設定

## レビュー項目

<!-- 動作確認の方法や、特に注意して見てほしい箇所を記載する -->

<!-- もしUIを変更している場合は、スクリーンショットを添付されているとありがたい -->

UI が正常に動作することを確認

<img height="500" alt="image" src="https://github.com/user-attachments/assets/c4310dcf-e273-4dd0-9e32-85f2bbb0a78d" />

## 備考

<!-- その他、レビュワーに伝えたいこと、議論、課題などがあれば記載する -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)