### PR TITLE
Worker の自動デプロイを GitHub Actions に追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,3 +35,21 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - name: Deploy Web
         run: pnpm deploy:web
+
+  deploy-worker:
+    runs-on: [self-hosted, macOS, ARM64]
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Restart worker daemon
+        run: |
+          cd apps/worker
+          pm2 delete worker || true
+          pm2 start "pnpm daemon" --name worker
+          pm2 save


### PR DESCRIPTION
## Summary
- GitHub Actions のデプロイワークフローに Worker デーモンの自動デプロイジョブを追加
- self-hosted ランナー（macOS ARM64）上で PM2 を使用してワーカープロセスを管理
- 既存プロセスを安全に停止してから再起動するパターンを採用

## Test plan
- [ ] main ブランチへのマージ後、デプロイワークフローが正常に実行されることを確認
- [ ] Worker デーモンが PM2 で正しく起動・管理されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)