### PR TITLE
hotfix: Worker デプロイ用の環境変数を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,13 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      ONESIGNAL_APP_ID: ${{ secrets.ONESIGNAL_APP_ID }}
+      ONESIGNAL_REST_API_KEY: ${{ secrets.ONESIGNAL_REST_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Worker デプロイに必要な環境変数を GitHub Actions ワークフローに追加
- 追加した環境変数: DATABASE_URL, SUPABASE_URL, SUPABASE_ANON_KEY, ONESIGNAL_APP_ID, ONESIGNAL_REST_API_KEY, GOOGLE_API_KEY, OPENAI_API_KEY

## Test plan
- [ ] GitHub Actions でワークフローが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)