### PR TITLE
[worker] daily-update ジョブのリファクタリング

### DIFF
--- a/apps/worker/src/tasks/index.ts
+++ b/apps/worker/src/tasks/index.ts
@@ -11,10 +11,12 @@ export {
 } from "./ai-post";
 export {
   fetchImageAsBase64,
+  fetchUserPostsByDate,
   generateImage,
   getJstToday,
   getJstYesterday,
   getWeekStartDate,
+  processUserDailyUpdate,
 } from "./daily-update";
 export { checkDb, checkSupabase, type HealthCheckResult } from "./health";
 export {


### PR DESCRIPTION
## Summary

- `daily-update` ジョブを `jobs → tasks → lib` の依存関係に沿ってリファクタリング
- jobs/daily-update.ts から lib への直接呼び出しを削除

### 変更内容

| ファイル | 変更 |
|---------|------|
| `tasks/daily-update.ts` | `fetchUserPostsByDate`, `processUserDailyUpdate` を追加 |
| `tasks/index.ts` | 新しい関数をエクスポート |
| `jobs/daily-update.ts` | 簡素化（tasks からのみインポート） |

### 依存関係の改善

**Before:**
```
jobs/daily-update.ts
├── @/lib (直接呼び出し) ← 違反
└── @/tasks
```

**After:**
```
jobs/daily-update.ts
└── @/tasks
    └── @/lib
```

## Test plan

- [x] `pnpm worker typecheck` pass
- [x] `pnpm worker check` pass

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)