### PR TITLE
refactor(worker): ai-post ジョブを jobs → tasks 依存に統一 (#120)

### DIFF
--- a/apps/worker/src/tasks/index.ts
+++ b/apps/worker/src/tasks/index.ts
@@ -1,12 +1,16 @@
 export {
   AI_POST_CONFIG,
   type DiaryGroup,
+  fetchRandomHistoricalPosts,
+  fetchRecentUserPosts,
   type GenerationResult,
   generateAiPostContents,
   generateStandaloneAiPostContents,
   generateStandalonePosts,
   getRandomPublishedAt,
   groupPostsByUser,
+  processHistoricalAiPost,
+  processUserAiPosts,
   shouldExecuteWithChance,
 } from "./ai-post";
 export {


### PR DESCRIPTION
## Summary

- `tasks/ai-post.ts` に以下の関数を追加:
  - `fetchRecentUserPosts`: 直近のユーザー投稿を取得するラッパー
  - `fetchRandomHistoricalPosts`: ランダムな過去投稿を取得するラッパー  
  - `processUserAiPosts`: ユーザー投稿からAI投稿を生成する処理を統合
  - `processHistoricalAiPost`: 過去投稿からAI投稿を生成する処理を統合
- `jobs/ai-post-short-term.ts` と `jobs/ai-post-long-term.ts` を簡素化し、lib 直接依存を削除

## Test plan

- [x] `pnpm worker typecheck` パス
- [x] `pnpm worker check` パス

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)