### PR TITLE
fix(native): ホームタイムラインの重複エントリエラーを修正

### DIFF
--- a/apps/native/src/features/timeline/hooks/use-timeline.ts
+++ b/apps/native/src/features/timeline/hooks/use-timeline.ts
@@ -1,5 +1,5 @@
 import type { TimelineEntry } from "@packages/schema/entry";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { useAuth } from "@/contexts/auth-context";
 import { createAuthenticatedClient } from "@/lib/api";
@@ -48,6 +48,10 @@ export const useTimeline = () => {
     hasMore: false,
   });
 
+  // 二重呼び出し防止用のref
+  const isFetchingRef = useRef(false);
+  const isFetchingMoreRef = useRef(false);
+
   const fetchTimeline = useCallback(async () => {
     if (!accessToken) {
       setState({
@@ -60,6 +64,13 @@ export const useTimeline = () => {
       });
       return;
     }
+
+    // 既にフェッチ中なら何もしない
+    if (isFetchingRef.current) {
+      logger.debug("fetchTimeline skipped: already fetching");
+      return;
+    }
+    isFetchingRef.current = true;
 
     setState((prev) => ({ ...prev, isLoading: true, error: null }));
     logger.debug("Fetching timeline");
@@ -101,6 +112,8 @@ export const useTimeline = () => {
         isLoading: false,
         error: "通信エラーが発生しました",
       }));
+    } finally {
+      isFetchingRef.current = false;
     }
   }, [accessToken]);
 
@@ -113,6 +126,13 @@ export const useTimeline = () => {
     ) {
       return;
     }
+
+    // 既にフェッチ中なら何もしない（refresh との競合防止）
+    if (isFetchingRef.current || isFetchingMoreRef.current) {
+      logger.debug("fetchMore skipped: fetch in progress");
+      return;
+    }
+    isFetchingMoreRef.current = true;
 
     setState((prev) => ({ ...prev, isFetchingMore: true }));
     logger.debug("Fetching more timeline", { cursor: state.nextCursor });
@@ -130,13 +150,24 @@ export const useTimeline = () => {
           count: data.entries.length,
           hasMore: data.hasMore,
         });
-        setState((prev) => ({
-          ...prev,
-          entries: [...prev.entries, ...data.entries],
-          isFetchingMore: false,
-          nextCursor: data.nextCursor,
-          hasMore: data.hasMore,
-        }));
+        setState((prev) => {
+          // 重複排除: 既存のIDセットを作成
+          const existingIds = new Set(
+            prev.entries.map((e) => `${e.type}-${e.id}`),
+          );
+          // 新しいエントリから重複を除外
+          const newEntries = data.entries.filter(
+            (e: TimelineEntry) => !existingIds.has(`${e.type}-${e.id}`),
+          );
+
+          return {
+            ...prev,
+            entries: [...prev.entries, ...newEntries],
+            isFetchingMore: false,
+            nextCursor: data.nextCursor,
+            hasMore: data.hasMore,
+          };
+        });
       } else {
         logger.warn("Fetch more failed", { status: res.status });
         setState((prev) => ({
@@ -151,12 +182,12 @@ export const useTimeline = () => {
         ...prev,
         isFetchingMore: false,
       }));
+    } finally {
+      isFetchingMoreRef.current = false;
     }
   }, [accessToken, state.nextCursor, state.isFetchingMore, state.hasMore]);
 
-  useEffect(() => {
-    fetchTimeline();
-  }, [fetchTimeline]);
+  // useEffect は削除 - useFocusEffect に統一（home-screen.tsx で呼び出し）
 
   return {
     entries: state.entries,


### PR DESCRIPTION
## 関連 issue

resolve #133

## やったこと

- `useTimeline` フックの二重呼び出し問題を修正
  - `useEffect` を削除し、`useFocusEffect` に統一
  - `isFetchingRef` による二重呼び出し防止を追加
  - `fetchMore` での重複排除処理を追加

## レビュー項目

- [ ] ホーム画面で「同じキーの子要素が重複」エラーが発生しないこと
- [ ] タイムラインのスクロールで追加読み込みが正常に動作すること
- [ ] 画面再フォーカス時にリフレッシュが正常に動作すること

## 備考

### 原因分析

初回レンダリング時に以下の2箇所からデータ取得が発生し、レースコンディションで重複エントリが発生していた：

1. `useTimeline` 内の `useEffect`
2. `HomeScreen` の `useFocusEffect`

### 対策

| 変更点 | 説明 |
|--------|------|
| `useEffect` 削除 | `useFocusEffect` と重複していたため |
| `isFetchingRef` 追加 | `fetchTimeline` の二重呼び出し防止 |
| `isFetchingMoreRef` 追加 | `fetchMore` の二重呼び出し防止 |
| 重複排除処理 | 競合時に同じエントリが追加されることを防止 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)