### PR TITLE
fix(worker): weekly world未存在時にデフォルトから作成 & seed削除 #153

### DIFF
--- a/apps/worker/src/lib/llm-config.ts
+++ b/apps/worker/src/lib/llm-config.ts
@@ -23,7 +23,6 @@ export const LLM_CONFIG = {
   imageGeneration: {
     model: "gemini-3-pro-image-preview",
     temperature: 0.1,
-    seed: 1234,
     candidateCount: 1,
   },
 


### PR DESCRIPTION
## Summary

- daily-update時にuserがworldを持っていない場合、エラーを出力する代わりにbase.pngで新規作成するように変更
- 画像生成のdebug用seed値（`seed: 1234`）を削除し、本番環境で毎回異なる画像が生成されるように修正

## Changes

- `findWeeklyWorld`でnull判定し、存在しない場合は`createWeeklyWorld`で新規作成
- `LLM_CONFIG.imageGeneration`からseedを削除

## Test plan

- [ ] daily-updateジョブを手動実行し、worldが存在しないユーザーで新規作成されることを確認
- [ ] 画像生成が毎回異なる結果になることを確認

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)